### PR TITLE
updated password to conform with stricter rules in installer

### DIFF
--- a/scripts/install-sql-server.cmd
+++ b/scripts/install-sql-server.cmd
@@ -1,3 +1,3 @@
 :: /SAPWD = password.  Probably don't futz with the other parameters
 :: For a full list: https://msdn.microsoft.com/en-us/library/ms144259(v=sql.110).aspx
-C:\vagrant\SQLEXPRWT_x64_ENU.exe /Q /Action=install /INDICATEPROGRESS /INSTANCENAME="SQLEXPRESS" /INSTANCEID="SQLExpress" /IAcceptSQLServerLicenseTerms /FEATURES=SQL,Tools /TCPENABLED=1 /SECURITYMODE="SQL" /SAPWD="password1"
+C:\vagrant\SQLEXPRWT_x64_ENU.exe /Q /Action=install /INDICATEPROGRESS /INSTANCENAME="SQLEXPRESS" /INSTANCEID="SQLExpress" /IAcceptSQLServerLicenseTerms /FEATURES=SQL,Tools /TCPENABLED=1 /SECURITYMODE="SQL" /SAPWD="password12!"


### PR DESCRIPTION
It looks like the password validation rules were changed in the installer - now it fails without a special character.
